### PR TITLE
Problem: missing runtime depends on avahi-daemon

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -55,7 +55,7 @@ Description: this service manages network anouncement (mdns) and discovery (dns-
 
 Package: fty-mdns-sd
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends},
+Depends: ${misc:Depends}, ${shlibs:Depends}, avahi-daemon
 Description: this service manages network anouncement (mdns) and discovery (dns-sd)
  Main package for fty-mdns-sd: this service manages network anouncement (mdns) and discovery (dns-sd)
 

--- a/packaging/redhat/fty-mdns-sd.spec
+++ b/packaging/redhat/fty-mdns-sd.spec
@@ -56,6 +56,7 @@ BuildRequires:  malamute-devel
 BuildRequires:  avahi-client-devel
 BuildRequires:  fty-proto-devel
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+Requires:       avahi
 
 %description
 fty-mdns-sd this service manages network anouncement (mdns) and discovery (dns-sd).


### PR DESCRIPTION
Solution: add it, for now for Debian only

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>