### PR TITLE
Problem : I want to ensure unexpected ERROR from fty-info never happens

### DIFF
--- a/src/fty_mdns_sd_server.cc
+++ b/src/fty_mdns_sd_server.cc
@@ -201,9 +201,11 @@ s_poll_fty_info(fty_mdns_sd_server_t *self)
         return -3;
     }
 
-    char *zuuid_reply = zmsg_popstr (resp);
+    char *zuuid_or_error = zmsg_popstr (resp);
+    //assert no unexpected ERROR reported 
+    assert(strneq (zuuid_or_error, "ERROR"));
     //TODO : check UUID if you think it is important
-    zstr_free(&zuuid_reply);
+    zstr_free(&zuuid_or_error);
     zuuid_destroy(&uuid);
 
     char *cmd = zmsg_popstr (resp);


### PR DESCRIPTION
As first step of investigation of coredump (IPMCVG-853) of fty-mdn-sd, ensure fty-info never respond ERROR.
Signed-off-by: eaton <eaton@jessie64>