### PR TITLE
 Problem: Agent should retry INFO command, not abort 

### DIFF
--- a/src/fty_mdns_sd_server.cc
+++ b/src/fty_mdns_sd_server.cc
@@ -335,7 +335,8 @@ s_handle_pipe(fty_mdns_sd_server_t* self, zmsg_t **message_p)
             if (rv == 0)
                 break;
             // Wait 5 seconds before retrying
-            zclock_sleep (5000);
+            if (tries == 0)
+                zclock_sleep (5000);
         }
         // sanity check, this should trigger a service abort then restart
         // in the worst case, if we did not succeeded after 3 tries

--- a/src/fty_mdns_sd_server.cc
+++ b/src/fty_mdns_sd_server.cc
@@ -208,7 +208,10 @@ s_poll_fty_info(fty_mdns_sd_server_t *self)
     zuuid_destroy(&uuid);
 
     char *cmd = zmsg_popstr (resp);
-    assert(streq (cmd, "INFO"));
+    if(strneq (cmd, "INFO")) {
+        zsys_error ("%s: not received INFO command (%s)", __func__, cmd);
+        return -4;
+    }
     char *srv_name  = zmsg_popstr (resp);
     char *srv_type  = zmsg_popstr (resp);
     char *srv_stype = zmsg_popstr (resp);
@@ -325,7 +328,17 @@ s_handle_pipe(fty_mdns_sd_server_t* self, zmsg_t **message_p)
         self->fty_info_command = zmsg_popstr (message);
         zsys_debug("fty-mdns-sd-server: DO-DEFAULT-ANNOUNCE %s",
                 self->fty_info_command);
-        int rv=s_poll_fty_info(self);
+        int rv = -1;
+        int tries = 3;
+        while (tries-- >= 0) {
+            rv=s_poll_fty_info(self);
+            if (rv == 0)
+                break;
+            // Wait 5 seconds before retrying
+            zclock_sleep (5000);
+        }
+        // sanity check, this should trigger a service abort then restart
+        // in the worst case, if we did not succeeded after 3 tries
         assert(rv==0);
         self->service->setServiceDefinition(
             self->srv_name,


### PR DESCRIPTION
Solution: Implement a retry mechanism and relaxed checks
Reworked version from 1.3

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>